### PR TITLE
Fixes direct RTU/serial connection to inverter

### DIFF
--- a/semp-rtu.conf
+++ b/semp-rtu.conf
@@ -10,10 +10,12 @@
 # Parity setting, N, E or O
 # optional, default: E
 #parity = E
+parity = N
 
 # Serving serial timeout, depends on line speed.
-# optional, integer, default: 1
+# optional, float, default: 1
 #timeout = 1
+timeout = 0.1
 
 # Logging level, CRITICAL, ERROR, WARNING, INFO, DEBUG
 # optional, default: INFO

--- a/semp-rtu.py
+++ b/semp-rtu.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
             port=confparser["server"].get("device", fallback=default_config["server"]["device"]),
             baudrate=confparser["server"].get("baud", fallback=default_config["server"]["baud"]),
             parity=confparser["server"].get("parity", fallback=default_config["server"]["parity"]),
-            timeout=confparser["server"].get("timeout", fallback=default_config["server"]["timeout"])
+            timeout=float(confparser["server"].get("timeout", fallback=default_config["server"]["timeout"]))
         )
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
The timeout property in a serial context means how long
a read can be ongoing trying to fill the supplied buffer.

The default value of 1 second creates a situation where the
simulated modbus slave appears to be nonresponsive from the
SolarEdge inverter's perspective, as it issues a read request
and for up to a second, the slave does not respond. The WattNode
physical device is specified to respond within 200 ms. Its
default setting with regards to parity is N1, i.e. no parity, 1
stop bit.

Allow fractional seconds as timeout and lower the serial timeout
to 0.1 s, which risks more incomplete RTU frames to be returned
from the serial library, but this is normal and handled by the
pymodbus library.